### PR TITLE
Only generate version from GitVersion on master builds

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -3,12 +3,7 @@ set -euo pipefail
 
 export VERSION=ci
 export FULL_VERSION=ci-full
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-    # GitVersion fix: https://github.com/GitTools/GitVersion/issues/1671#issuecomment-508198452
-    git remote set-branches --add origin master
-    git checkout --track origin/master
-    git checkout "${TRAVIS_BRANCH}"
-
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then
     VERSION=$(docker run -it --rm -v "$(pwd):/repo" gittools/gitversion:5.0.0-linux-debian-9-netcoreapp2.2 /repo /showvariable NuGetVersionV2 | tee /dev/tty)
     FULL_VERSION=$(docker run -it --rm -v "$(pwd):/repo" gittools/gitversion:5.0.0-linux-debian-9-netcoreapp2.2 /repo /showvariable InformationalVersion | tee /dev/tty)
 fi


### PR DESCRIPTION
After merging PR #1, the master branch builds started failing due to trying to workaround issues with GitVersion and branch/PR builds. These changes will only generate a version during master builds, which are the only builds that actually need a version attached to them.