### PR TITLE
Fix go.mod for Go 1.13+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ all: build-prepare lint test build
 
 build-prepare:
 	mkdir -p $(DIST)
-	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
-	go get -u github.com/mattn/goveralls
+	GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+	GO111MODULE=off go get -u github.com/mattn/goveralls
 
-lint: 
+lint:
 	$(GOLANGCI_LINT_RUN) ./...
 
 test:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hylandsoftware/trebuchet
 
 go 1.12
 
-replace github.com/docker/docker v1.13.1 => github.com/docker/engine v0.0.0-20180816081446-200b524eff60
+replace github.com/docker/docker v1.13.1 => github.com/docker/engine v0.0.0-20190327083406-200b524eff60
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/engine v0.0.0-20180816081446-200b524eff60 h1:XDe+modXkPfCsV8bFEJKwzfjhyBrWKIQw7G7hBeb3Ek=
-github.com/docker/engine v0.0.0-20180816081446-200b524eff60/go.mod h1:3CPr2caMgTHxxIAZgEMd3uLYPDlRvPqCpyeRf6ncPcY=
+github.com/docker/engine v0.0.0-20190327083406-200b524eff60 h1:kkJjcv8JQocgWPcmVPHUrXAmKcLMvgfqYCaLMfTm8vk=
+github.com/docker/engine v0.0.0-20190327083406-200b524eff60/go.mod h1:3CPr2caMgTHxxIAZgEMd3uLYPDlRvPqCpyeRf6ncPcY=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.3.3 h1:Xk8S3Xj5sLGlG5g67hJmYMmUgXv5N4PhkjJHHqrwnTk=


### PR DESCRIPTION
Go 1.13 introduces stricter version checks. The timestamp for v0.0.0 dependencies must match the timestamp of the commit. I've also disabled `GO111MODULE` in the `Makefile` when we install tools. Without this Go wants to pull in all of *their* dependencies, and there's tons of breaking package renames that I don't feel like fighting with (it also adds a ton of time to the build).