### PR TITLE
feat: add pull command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,39 @@ Global Flags:
   -v, --verbose         Enables verbose logging.
 ```
 
+`pull`:
+```
+Pulls a Docker image from ECR
+
+Strip:
+	Strip is a boolean flag. When set, it removes all ECR-specific elements from the image name. For example, 
+	112233445566.dkr.ecr.us-east-1.amazonaws.com/hello-world:latest would be pulled as hello-world:latest.
+
+Region:
+	Region is required to be set as a flag, as an AWS environment variable (AWS_DEFAULT_REGION), or in the AWS config.
+
+Amazon Resource Name (ARN):
+	Passing in a valid ARN allows trebuchet to assume a role to perform actions within AWS. A typical use-case for this
+	would be a service account to use in a software pipeline to push images to ECR.
+
+Usage:
+  treb pull NAME[:TAG] [flags]
+
+Exmaples:
+treb pull -v --strip --region us-east-1 helloworld:1.2.3
+treb pull -v -s --as arn:aws:iam::112233445566:role/PushToECR --region us-west-1 hello/world:3.4-beta
+treb pull helloworld:latest
+
+Flags:
+  -h, --help   help for repository
+  -s, --strip  strip the image name of ECR-specific elements
+
+Global Flags:
+  -a, --as string       Amazon Resource Name (ARN) specifying the role to be assumed.
+  -r, --region string   AWS region to be used. Supported as flag, AWS_DEFAULT_REGION environment variable or AWS Config File.
+  -v, --verbose         Enables verbose logging.
+```
+
 `repository`: 
 ```
 Get the full URL of a repository in Amazon ECR. The repository command will lookup the repository passed in
@@ -111,7 +144,8 @@ to create the repository if it doesn't exist and push images into ECR:
                 "ecr:UploadLayerPart",
                 "ecr:InitiateLayerUpload",
                 "ecr:BatchCheckLayerAvailability",
-                "ecr:PutImage"
+                "ecr:PutImage",
+                "ecr:GetDownloadUrlForLayer"
             ],
             "Resource": "*"
         }

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"github.com/hylandsoftware/trebuchet/internal/docker"
+	"github.com/hylandsoftware/trebuchet/internal/ecr"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var pullCmd = &cobra.Command{
+	Use:     "pull NAME[:TAG]",
+	Args:    cobra.ExactArgs(1),
+	Example: `treb pull -v --region us-east-1 helloworld:1.2.3
+treb pull -v --as arn:aws:iam::112233445566:role/PullFromECR --region us-west-1 hello/world:3.4-beta
+treb pull --strip helloworld:latest`,
+	Short: "Pulls a Docker image from ECR",
+	Long: `Pulls a Docker image from ECR
+
+Strip:
+	Strip is a boolean flag. When set, it removes all ECR-specific elements from the image name. For example, 
+	112233445566.dkr.ecr.us-east-1.amazonaws.com/hello-world:latest would be pulled as hello-world:latest.
+
+Region:
+	Region is required to be set as a flag, as an AWS environment variable (AWS_DEFAULT_REGION), or in the AWS config.
+
+Amazon Resource Name (ARN):
+	Passing in a valid ARN allows trebuchet to assume a role to perform actions within AWS. A typical use-case for this
+	would be a service account to use in a software pipeline to push images to ECR.`,
+	Run: pull,
+}
+
+func pull(cmd *cobra.Command, args []string) {
+	ecrClient, err := ecr.NewClient(viper.GetString("region"), viper.GetString("as"))
+	if err != nil {
+		log.WithError(err).Fatal("Error in creation of ECR client")
+	}
+
+	dockerClient, err := docker.NewClient()
+	if err != nil {
+		log.WithError(err).Fatal("Error creating Docker client")
+	}
+
+	dockerImage := args[0]
+	repository := parseDockerRepositoryFromImage(dockerImage)
+
+	if ok, _ := ecrClient.RepositoryExists(repository); !ok {
+		log.Fatal("ECR repository does not exist")
+	}
+
+	repositoryURI, err := ecrClient.GetRepositoryURI(repository)
+	if err != nil {
+		log.WithError(err).Fatal("Error retrieving full repository name")
+	}
+
+	auth, err := ecrClient.GetAuthorizationToken()
+	if err != nil {
+		log.WithError(err).Fatal("Error getting authorization token for ECR")
+	}
+
+	if err := docker.Pull(dockerClient, dockerImage, repositoryURI, viper.GetBool("strip"), *auth); err != nil {
+		log.WithError(err).WithField("image", dockerImage).Fatal("Error pulling Docker image")
+	}
+}
+
+func init() {
+	flags := pullCmd.Flags()
+	flags.BoolP("strip", "s", true, "strip the image name of ECR-specific elements")
+	_ = viper.BindPFlags(flags)
+	rootCmd.AddCommand(pullCmd)
+}

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -23,6 +23,11 @@ func (m *mockDockerClient) ImagePush(image string, auth ecr.RegistryAuth) error 
 	return args.Error(0)
 }
 
+func (m *mockDockerClient) ImagePull(image string, auth ecr.RegistryAuth) error {
+	args := m.Called(image, auth)
+	return args.Error(0)
+}
+
 func (m *mockDockerClient) ImageTag(source string, target string) error {
 	args := m.Called(source, target)
 	return args.Error(0)
@@ -62,6 +67,34 @@ func TestDockerClient_Push_ImagePushReturnsError(t *testing.T) {
 	err := TagAndPush(m, "", "", ecr.RegistryAuth{})
 
 	require.EqualError(t, err, "error: %!s(<nil>)")
+}
+
+func TestDockerClient_Pull_ValidPull(t *testing.T) {
+	m := &mockDockerClient{}
+	m.On("ImagePull", mock.Anything, ecr.RegistryAuth{}).Return(nil)
+
+	err := Pull(m, "", "", false, ecr.RegistryAuth{})
+
+	require.NoError(t, err)
+}
+
+func TestDockerClient_Pull_ImageTagReturnsError(t *testing.T) {
+	m := &mockDockerClient{}
+	m.On("ImagePull", mock.Anything, ecr.RegistryAuth{}).Return(nil)
+	m.On("ImageTag", mock.Anything, mock.Anything).Return(errors.New("error"))
+
+	err := Pull(m, "", "", true, ecr.RegistryAuth{})
+
+	require.EqualError(t, err, "error")
+}
+
+func TestDockerClient_Pull_ImagePullReturnsError(t *testing.T) {
+	m := &mockDockerClient{}
+	m.On("ImagePull", mock.Anything, ecr.RegistryAuth{}).Return(errors.New("error"))
+
+	err := Pull(m, "", "", false, ecr.RegistryAuth{})
+
+	require.EqualError(t, err, "error")
 }
 
 func TestDockerClient_GetFullECRImageReference_EmptySuffixReturnsOnlyURI(t *testing.T) {


### PR DESCRIPTION
Added a `pull` command. 

This command uses identical authorization to the `push` command. It also adds a `--strip` flag, which will remove the ECR-specific parts of the image name. 

For example, `112233445566.dkr.ecr.us-east-1.amazonaws.com/hello-world:latest` would be pulled as `hello-world:latest`