### PR TITLE
Fix docker:dind to latest 20.10.x version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker:dind
+FROM docker:20.10-dind
 
 COPY dist/treb /usr/bin/treb


### PR DESCRIPTION
The previous build used docker:dind latest which was 19.x at the time. A 20.10 version is needed.